### PR TITLE
added documentation for /schedule/week endpoint

### DIFF
--- a/docs/GraphQL-API/learn_more.md
+++ b/docs/GraphQL-API/learn_more.md
@@ -70,7 +70,7 @@ Here, we will talk more about how to use GraphQL for the PeterPortal API. I reco
 
 ### Queries
 
-Our API has 6 queries you can use to make a request for data. 
+Our API has 7 queries you can use to make a request for data. 
 
 * `course`
 * `instructor`

--- a/docs/GraphQL-API/learn_more.md
+++ b/docs/GraphQL-API/learn_more.md
@@ -78,6 +78,7 @@ Our API has 6 queries you can use to make a request for data.
 * `allInstructors`
 * `schedule`
 * `grades`
+* `week`
 
 Each query returns an object of a certain type. For example, a `course` query will return a `Course` type, and an `allCourses` query will return a list of `Course` types. 
 

--- a/docs/REST-API/schedule.md
+++ b/docs/REST-API/schedule.md
@@ -278,5 +278,52 @@ Descriptions found [here](https://www.reg.uci.edu/help/WebSoc-Glossary.shtml)
     
     ```
 
-
 This endpoint is based off of this [npm package](https://github.com/icssc-projects/websoc-api) with help from AntAlmanac developers.
+
+### `/schedule/week`
+
+**GET week and quarter data**
+
+This API gets the week and quarter of the school year given a certain date. Default date is today's date.
+
+#### Parameters
+
+| Name             | Formatting                                                                                                                                                                                                                                                                                                                                                      | Notes                                                                                         |
+|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| year           | YYYY<br/>Example: '2021' <br/> Default: ' '                                                                                                                                                                                                                     | If out of range will interpret as a school break                     |
+| month               | MM<br/>Example: '10' <br/> Default: ' '                                                                                                                                                                     |                   |
+| day               |DD<br/>Example: '08' <br/> Default: ' '                                                                                                                                                                       |                 |
+
+#### Response
+
+| Code | Description |
+|------|-------------|
+| `200` | A JSON object containing the week number, and quarter term. |
+| `400` | Invalid parameter syntax. |
+
+
+??? success "200 Successful Response"
+To get the week and quarter of October 6, 2021:
+
+    `/schedule/week/?year=2021&month=10&day=06` returns
+
+    ``` JSON
+    {
+        "week":2,
+        "quarter":"Fall 2021",
+        "display":"Week 2 • Fall 2021"
+    }
+    ```
+
+??? fail "400 Bad Request"
+
+    `/schedule/week/?year=2021&month=20&day=6` returns
+
+    ``` JSON
+    {
+        "timestamp":"Mon, 25 Apr 2022 01:19:21 GMT",
+        "status":400,
+        "error":"Bad Request: Invalid parameter",
+        "message":"Invalid year, month or day. Must include all year, month and day or none."}
+    
+    ```

--- a/docs/REST-API/schedule.md
+++ b/docs/REST-API/schedule.md
@@ -303,7 +303,7 @@ This API gets the week and quarter of the school year given a certain date. Defa
 
 
 ??? success "200 Successful Response"
-To get the week and quarter of October 6, 2021:
+    To get the week and quarter of October 6, 2021:
 
     `/schedule/week/?year=2021&month=10&day=06` returns
 


### PR DESCRIPTION
## Reference Issues
#192 

## Summary of Change/Fix 
Added documentation for the /schedule/week endpoint for Schedule of Classes REST API. Includes parameter descriptions and sample responses. Added documentation for Graphql API for /schedule/week endpoint.

## Test Plan
Run locally to ensure /schedule/week documentation is listed under REST API -> Schedule of Classes.
