### PR TITLE
Renamed instances of icssc-projects github url to icssc

### DIFF
--- a/docs/Contributing/documenting.md
+++ b/docs/Contributing/documenting.md
@@ -13,7 +13,7 @@ For GraphQL documentation, the playground generates the documentation for us aut
 
 **📝 Writing documentation is simple with MkDocs.**
 
-1. Open up the project, and navigate to the [`/docs`](https://github.com/icssc-projects/peterportal-public-api/tree/master/docs) folder.
+1. Open up the project, and navigate to the [`/docs`](https://github.com/icssc/peterportal-public-api/tree/master/docs) folder.
 2. Make your changes to the markdown (`.md`) files within this folder.
 3. Create a pull request to `master`. Once your pull request is merged with `master`, the documentation site will be automatically rebuilt.
 
@@ -31,5 +31,5 @@ For GraphQL documentation, the playground generates the documentation for us aut
 
 Preview your changes with `mkdocs serve`, and see the generated documentation locally with `mkdocs build -d docs-site`. 
 
-Configure documentation site settings in [`/mkdocs.yml`](https://github.com/icssc-projects/peterportal-public-api/blob/master/mkdocs.yml).
+Configure documentation site settings in [`/mkdocs.yml`](https://github.com/icssc/peterportal-public-api/blob/master/mkdocs.yml).
 

--- a/docs/Contributing/how_to_contribute.md
+++ b/docs/Contributing/how_to_contribute.md
@@ -4,7 +4,7 @@
 
 If you're wondering how to contribute to open source project and this is your first time, you're at the right place. 
 
-1. First, you'll want to fork the repository to your own account. You can do that by clicking the fork button in the top right of our [repository](https://github.com/icssc-projects/peterportal-public-api). 
+1. First, you'll want to fork the repository to your own account. You can do that by clicking the fork button in the top right of our [repository](https://github.com/icssc/peterportal-public-api). 
 2. Clone the forked respository to your local machine. Click the green **Code** button, and copy the URL. Open up a terminal on your local computer to where you want the repository to be and enter: 
 
      ```
@@ -25,7 +25,7 @@ If you're wondering how to contribute to open source project and this is your fi
 4. Add the project repository as the "upstream" remote. You can do that by entering this command: 
 
     ```
-    git remote add upstream https://github.com/icssc-projects/peterportal-public-api.git
+    git remote add upstream https://github.com/icssc/peterportal-public-api.git
     ```
     
 5. Use `git remote -v` to check that you have 2 remotes. An origin that points to your forked repository on your account, and upstream that points to this project repository. 

--- a/docs/Contributing/start_here.md
+++ b/docs/Contributing/start_here.md
@@ -1,27 +1,27 @@
 # Contributing
 
-PeterPortal API is an open source project, [hosted on Github](https://github.com/icssc-projects/peterportal-public-api), created by the ICS Student Council Projects Committee at UCI. We welcome all UCI students to contribute to our project and improve our API.
+PeterPortal API is an open source project, [hosted on Github](https://github.com/icssc/peterportal-public-api), created by the ICS Student Council Projects Committee at UCI. We welcome all UCI students to contribute to our project and improve our API.
 
 Our goal is to encourage more students and developers to create applications beneficial to the UCI community. 
 
 ## Want to get Involved?
 
-We would love for you to help us out! UCI students can look to contribute to this open source project on GitHub. Our repository can be found [here](https://github.com/icssc-projects/peterportal-public-api). 
+We would love for you to help us out! UCI students can look to contribute to this open source project on GitHub. Our repository can be found [here](https://github.com/icssc/peterportal-public-api). 
 
 If you are looking to join our team and be even more involved, ICS Student Council recruits students at the beginning of every school year to their committees. For more information, please visit <https://studentcouncil.ics.uci.edu/>.
 
 ## What should you work on?
 
-You can check out which issues we need help on our [repo](https://github.com/icssc-projects/peterportal-public-api). 
+You can check out which issues we need help on our [repo](https://github.com/icssc/peterportal-public-api). 
 
-Check out these issues we have labeled [help wanted](https://github.com/icssc-projects/peterportal-public-api/labels/help%20wanted). If you're a beginner, we recommend looking at some [good first tasks](https://github.com/icssc-projects/peterportal-public-api/labels/good%20first%20task).
+Check out these issues we have labeled [help wanted](https://github.com/icssc/peterportal-public-api/labels/help%20wanted). If you're a beginner, we recommend looking at some [good first tasks](https://github.com/icssc/peterportal-public-api/labels/good%20first%20task).
 
 ## How to get in touch?
 
 If you have feature requests, questions, ideas, and want to contribute, there are multiple channels you can communicate with us. 
 
 ### :material-github: GitHub
-Repository: <https://github.com/icssc-projects/peterportal-public-api>
+Repository: <https://github.com/icssc/peterportal-public-api>
 
  - Issues and Bugs
  - Feature Requests

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-![petr](https://github.com/icssc-projects/peterportal-public-api/blob/master/public/images/peterportal-banner-logo.png?raw=true)
+![petr](https://github.com/icssc/peterportal-public-api/blob/master/public/images/peterportal-banner-logo.png?raw=true)
 
 PeterPortal Public API provides software developers with easy-access to UC Irvine publicly available data such as: courses information, professor information, grade distribution, and schedule of classes.
 
@@ -30,7 +30,7 @@ We consolidate our data directly from official UCI sources such as: UCI Catalogu
 👩‍💻 We are currently in the early stages for this project. Anyone is welcome to integrate this API into your project as a tool. However, if you choose to do so, please be aware that this project is currently in its early release phase. Every user will be considered as testers and are highly encouraged to do their part and submit a bug report if you encounter any issues. Our team will respond as quickly as possible to resolve the issue.
 
 ## Bug Report
-🐞 If you encountered any issues or bug, please open an issue @ https://github.com/icssc-projects/peterportal-public-api/issues/new
+🐞 If you encountered any issues or bug, please open an issue @ https://github.com/icssc/peterportal-public-api/issues/new
 
 
 ## Other Disclaimer
@@ -42,7 +42,7 @@ We consolidate our data directly from official UCI sources such as: UCI Catalogu
 ## Setting up to develop the project locally
 1. Clone the `peterportal-public-api` repository to your local machine.
    ```
-   git clone git@github.com:icssc-projects/peterportal-public-api.git
+   git clone git@github.com:icssc/peterportal-public-api.git
    ```
 2. Change into the project directory.
    ```

--- a/docs/REST-API/schedule.md
+++ b/docs/REST-API/schedule.md
@@ -278,7 +278,7 @@ Descriptions found [here](https://www.reg.uci.edu/help/WebSoc-Glossary.shtml)
     
     ```
 
-This endpoint is based off of this [npm package](https://github.com/icssc-projects/websoc-api) with help from AntAlmanac developers.
+This endpoint is based off of this [npm package](https://github.com/icssc/websoc-api) with help from AntAlmanac developers.
 
 ### `/schedule/week`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-![petr](https://github.com/icssc-projects/peterportal-public-api/blob/master/public/images/peterportal-banner-logo.png?raw=true)
+![petr](https://github.com/icssc/peterportal-public-api/blob/master/public/images/peterportal-banner-logo.png?raw=true)
 
 PeterPortal Public API provides software developers with easy-access to UC Irvine publicly available data such as: course information, professor information, grade distribution, and schedule of classes.
 
@@ -33,7 +33,7 @@ We consolidate our data directly from official UCI sources such as: UCI Catalogu
 👩‍💻 We are currently in the early stages for this project. Anyone is welcome to integrate this API into your project as a tool. However, if you choose to do so, please be aware that this project is currently in its early release phase. Every user will be considered as testers and are highly encouraged to do their part and submit a bug report if you encounter any issues. Our team will respond as quickly as possible to resolve the issue. 
 
 !!! bug
-    If you encountered any issues or bug, please open an issue @ <https://github.com/icssc-projects/peterportal-public-api/issues/new>
+    If you encountered any issues or bug, please open an issue @ <https://github.com/icssc/peterportal-public-api/issues/new>
 
 
 ??? warning "Other Disclaimer"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: PeterPortal API Docs
 
-repo_url: https://github.com/icssc-projects/peterportal-public-api
-repo_name: icssc-projects/peterportal-public-api
+repo_url: https://github.com/icssc/peterportal-public-api
+repo_name: icssc/peterportal-public-api
 
 theme:
   name: material
@@ -57,7 +57,7 @@ extra:
     - icon: fontawesome/brands/medium
       link: https://icsscprojects.medium.com/
     - icon: fontawesome/brands/github
-      link: https://github.com/icssc-projects
+      link: https://github.com/icssc
 
 
 copyright: Copyright &copy; 2020 - 2021 ICSSC Projects


### PR DESCRIPTION
## Reference Issues
Closes #194 

## Summary of Change/Fix 
With the organization being renamed from `icssc-projects` to `icssc`, links to our GitHub in the documentation needed to be updated. They've been renamed as so. 

## Test Plan
Open up the documentation with `mkdocs serve`. Check for all references to github, and that they refer to this repository.