### PR TITLE
Added missing 'count' field to Grades

### DIFF
--- a/graphql/grades.ts
+++ b/graphql/grades.ts
@@ -31,7 +31,8 @@ const gradeDistributionCollectionAggregateType: GraphQLObjectType = new GraphQLO
     sum_grade_p_count: { type: GraphQLFloat }, 
     sum_grade_np_count: { type: GraphQLFloat }, 
     sum_grade_w_count: { type: GraphQLFloat }, 
-    average_gpa: { type: GraphQLFloat }
+    average_gpa: { type: GraphQLFloat },
+    count: {type: GraphQLFloat}
   })
 });
 

--- a/tests/int/graphql/grades.graphql.test.ts
+++ b/tests/int/graphql/grades.graphql.test.ts
@@ -18,6 +18,7 @@ describe('POST /graphql/', () => {
                 sum_grade_p_count
                 sum_grade_w_count
                 average_gpa
+                count
             }
             grade_distributions {
                 grade_a_count


### PR DESCRIPTION
## Summary of Change/Fix 
Missing `count` field on the Grades GraphQL queries was causing 400 errors. Added to tests, as well, since it was missed.
