### PR TITLE
Added dash to allowed instructor characters

### DIFF
--- a/helpers/grades.helper.ts
+++ b/helpers/grades.helper.ts
@@ -52,7 +52,7 @@ export function parseGradesParamsToSQL(query: {[key: string]: any;}) : WherePara
                 break;
             case key === 'instructor' && params[key] !== null:
                 for (let instructor of params[key]) {
-                    if (instructor.match(/^[a-zA-Z]+, [a-zA-Z]\.$/)) {
+                    if (instructor.match(/^[a-zA-Z\-]+, [a-zA-Z]\.$/)) {
                         condition == "" ? 
                             condition += "instructor = ?" :
                             condition += " OR instructor = ?"


### PR DESCRIPTION
## Reference Issues
An issue was discovered in PeterPortal where going to wong-ma would break, since the gradeData could not be fetched. 
![image](https://user-images.githubusercontent.com/9029237/170111663-53ab32b1-0543-4915-be83-b7e9c969d38c.png)

## Summary of Change/Fix 
The problem was that since there is a dash in the name, it wouldn't pass the check for syntax so it would fail and return a 400. Added a dash to the accepted characters in regex.  

## Test Plan
```
{
  grades (instructor:"WONG-MA, J."){
    aggregate {
      sum_grade_a_count
      sum_grade_b_count
      sum_grade_c_count
      sum_grade_d_count
      sum_grade_f_count
      sum_grade_p_count
      sum_grade_np_count
      average_gpa
	count
    }
  }
}
```