### PR TITLE
Added tests for Batch Queries

### DIFF
--- a/tests/int/rest/courses.int.test.ts
+++ b/tests/int/rest/courses.int.test.ts
@@ -63,3 +63,31 @@ describe('GET /courses/I&CSCI0000000', () => {
         expect(result['message']).toEqual("Course not found");
     }));
 });
+
+describe('GET /courses/I&CSCI46;I&CSCI53', () => {
+    it('returns an error message for a course that does not exist',  () => request
+    .get('/rest/v0/courses/I&CSCI46;I&CSCI53')
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .then((response) => {
+        const result: {[key: string]: Course} = response.body;
+        expect(result["I&CSCI46"]).toMatchObject({"number": "46", "department": "I&C SCI"});
+        expect(result["I&CSCI53"]).toMatchObject({"number": "53", "department": "I&C SCI"});
+        expect(Object.keys(result).length).toEqual(2);
+    }));
+});
+
+describe('GET /courses/I&CSCI46;I&CSCI0000000', () => {
+    it('returns correct for one course, and null for nonexistent course',  () => request
+    .get('/rest/v0/courses/I&CSCI46;I&CSCI0000000')
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .then((response) => {
+        const result: {[key: string]: Course} = response.body;
+        expect(result["I&CSCI46"]).toMatchObject({"number": "46", "department": "I&C SCI"});
+        expect(result["I&CSCI0000000"]).toBeNull();
+        expect(Object.keys(result).length).toEqual(2);
+    }));
+});

--- a/tests/int/rest/instructor.int.test.ts
+++ b/tests/int/rest/instructor.int.test.ts
@@ -46,3 +46,31 @@ describe('GET /instructors/randomguy', () => {
         expect(result['message']).toEqual("Instructor not found");
     }));
 });
+
+describe('GET /instructors/pattis;mikes', () => {
+    it('returns an error message for a course that does not exist',  () => request
+    .get('/rest/v0/instructors/pattis;mikes')
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .then((response) => {
+        const result: {[key: string]: Instructor} = response.body;
+        expect(result["pattis"]).toMatchObject({"name": "Richard Eric Pattis", "ucinetid": "pattis"});
+        expect(result["mikes"]).toMatchObject({"name": "Michael Shindler", "ucinetid": "mikes"});
+        expect(Object.keys(result).length).toEqual(2);
+    }));
+});
+
+describe('GET /instructors/pattis;nonexistent', () => {
+    it('returns correct for one course, and null for nonexistent course',  () => request
+    .get('/rest/v0/instructors/pattis;nonexistent')
+    .set('Accept', 'application/json')
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .then((response) => {
+        const result: {[key: string]: Instructor} = response.body;
+        expect(result["pattis"]).toMatchObject({"name": "Richard Eric Pattis", "ucinetid": "pattis"});
+        expect(result["nonexistent"]).toBeNull();
+        expect(Object.keys(result).length).toEqual(2);
+    }));
+});

--- a/tests/unit/courses.helper.unit.test.ts
+++ b/tests/unit/courses.helper.unit.test.ts
@@ -1,4 +1,4 @@
-import {getAllCourses, getCourse} from '../../helpers/courses.helper';
+import {getAllCourses, getCourse, getCourses} from '../../helpers/courses.helper';
 import {Course} from "../../types/types"
 
 
@@ -15,6 +15,18 @@ describe('Get all Courses', () => {
             expect(allCourses).toContainEqual(
                 expect.objectContaining({"number": "134E", "department": "ART HIS"})
             );
+        });
+    });
+});
+
+describe('Get some Courses', () => {
+    describe('Fetching some courses', () => {
+        it ('getAllCourses should return a json of all courses', () => {
+            const courses : {[key: string]: Course} = getCourses(["I&CSCI46", "ARTHIS134E"]);
+            expect(courses).not.toBeNull() 
+            expect(typeof courses).toBe("object");
+            expect(courses["I&CSCI46"]).toMatchObject({"number": "46", "department": "I&C SCI"});
+            expect(courses["ARTHIS134E"]).toMatchObject({"number": "134E", "department": "ART HIS"});
         });
     });
 });

--- a/tests/unit/instructor.helper.unit.test.ts
+++ b/tests/unit/instructor.helper.unit.test.ts
@@ -1,4 +1,4 @@
-import {getAllInstructors, getInstructor} from '../../helpers/instructor.helper';
+import {getAllInstructors, getInstructor, getInstructors} from '../../helpers/instructor.helper';
 import {Instructor} from "../../types/types";
 
 describe('Fetching all instructors', () => {
@@ -13,6 +13,16 @@ describe('Fetching all instructors', () => {
         expect(allInstructors).toContainEqual(
             expect.objectContaining({"name": "Alexander W Thornton", "ucinetid": "thornton"})
         );
+    });
+});
+
+describe('Fetching some instructors', () => {
+    it ('getInstructors should return a json of few courses requested', () => {
+        const instructors : {[key: string]: Instructor} = getInstructors(["pattis", "thornton"]);
+        expect(instructors).not.toBeNull() 
+        expect(typeof instructors).toBe("object");
+        expect(instructors["pattis"]).toMatchObject({"name": "Richard Eric Pattis", "ucinetid": "pattis"});
+        expect(instructors["thornton"]).toMatchObject({"name": "Alexander W Thornton", "ucinetid": "thornton"});
     });
 });
 


### PR DESCRIPTION
## Reference Issues
Closes #211 

## Summary of Change/Fix 
Adds batch queries to our testing. This includes both testing the new helper methods, as well as the new way to give parameters to the endpoint. 

Tests Added:
- Courses
  - Helper method returns key-{course object}
  - Rest endpoints return 200, and give correct responses for each course
  - nonexistent course returns null
- Instructors
  - Helper method returns key-{instructor object}
  - Rest endpoints return 200, and give correct responses for each instructor 
  - nonexistent instructor returns null 

## Test Plan
Run `npm test`

