### PR TITLE
Fix graphql grades(year) documentation

### DIFF
--- a/graphql/schema.ts
+++ b/graphql/schema.ts
@@ -253,7 +253,7 @@ const queryType: GraphQLObjectType = new GraphQLObjectType({
         year: {
           type: GraphQLString,
           description:
-            "Must be <START_YEAR>-<END_YEAR>. Ex. 2020-2021. Multiple values in the arguments can be included by using ; as a separator.",
+            "Must be <START_YEAR>-<END_YEAR>. Ex. 2020-21. Multiple values in the arguments can be included by using ; as a separator.",
         },
         quarter: {
           type: GraphQLString,


### PR DESCRIPTION
## Reference Issues

N/A

## Summary of Change/Fix

The description of the `year` argument of `grades` is different from its implementation. The implementation requires the `<END_YEAR>` to be 2 digits.

https://github.com/icssc/peterportal-public-api/blob/ed58126b9e2ff6af77d41624af678756a49e3d8f/helpers/grades.helper.ts#L43


## Test Plan

N/A
