### PR TITLE
Issue #221

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
       - run: npm ci
       - run: npm install
       - run: npm test
+      - run: npm run build
         env:
           MOESIF_KEY: ${{ secrets.MOESIF_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "nodemon server.ts",
     "test": "jest",
     "init_db": "node ./db/sqlite.js",
-    "refresh": "node ./utils/refreshESCache.js"
+    "refresh": "node ./utils/refreshESCache.js",
+    "build": "tsc"
   },
   "dependencies": {
     "@sentry/serverless": "^6.17.9",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "baseUrl": "./",
     "outDir": "./dist",
     "sourceMap": true,
-    "watch": true,
     "alwaysStrict": true,
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Reference Issues
Add TypeScript checks to actions

## Summary of Change/Fix
- Remove `"watch": true` from `tsconfig.json` to prevent test timeouts
- Add `"build": "tsc"` to `package.json` scripts for TypeScript compilation
- Add `npm run build` after `npm test` in `.github/workflows/tests.yml` 